### PR TITLE
Fix: Spring Security 권한 검증 방식 수정 (hasRole -> hasAuthority)

### DIFF
--- a/src/main/java/com/fisa/pg/service/AuthService.java
+++ b/src/main/java/com/fisa/pg/service/AuthService.java
@@ -11,10 +11,12 @@ import com.fisa.pg.repository.AdminRepository;
 import com.fisa.pg.repository.MerchantRepository;
 import com.fisa.pg.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -38,16 +40,11 @@ public class AuthService {
         Merchant merchant = merchantRepository.findByEmail(request.getEmail())
                 .orElseThrow(InvalidCredentialsException::new);
 
-        System.out.println("📌 사용자 입력 비번: " + request.getPassword());
-        System.out.println("📌 DB 저장된 비번: " + merchant.getPassword());
-        System.out.println("📌 매칭 결과: " + passwordEncoder.matches(request.getPassword(), merchant.getPassword()));
-
+        log.info("조회된 가맹점 정보: {}", merchant.getId());
 
         if (!merchant.isActive()) {
             throw new InvalidCredentialsException();
         }
-
-
 
         if (!passwordEncoder.matches(request.getPassword(), merchant.getPassword())) {
             throw new InvalidCredentialsException();
@@ -73,11 +70,10 @@ public class AuthService {
      */
     @Transactional
     public LoginResponseDto handleAdminLogin(LoginRequestDto request) {
-        System.out.println("📨 요청 받은 이메일: '" + request.getEmail() + "'");
-        System.out.println("🔍 DB 검색 결과: " + merchantRepository.findByEmail(request.getEmail()));
-
         Admin admin = adminRepository.findByEmail(request.getEmail())
                 .orElseThrow(InvalidCredentialsException::new);
+
+        log.info("조회된 관리자 정보: {}", admin.getId());
 
         if (!admin.isActive()) {
             throw new InvalidCredentialsException();


### PR DESCRIPTION
# 🚀 개요

Spring Security 권한 검증 방식 수정으로 관리자 API 접근 인증 문제 해결

## 🔍 변경사항

- Spring Security 권한 검증 방식을 hasRole()에서 hasAuthority()로 변경
- JWT 인증 필터와 Security 설정 간의 권한 검증 불일치 해결
- 관리자 API 엔드포인트 접근 오류 수정

## ⏳ 작업 내용

- [x] SecurityConfig 내 권한 검증 메소드 변경 (hasRole → hasAuthority)
- [x] JWT 필터와 Security 설정 간 권한 형식 일치화

### 📝 논의사항

- JWT 필터에서는 role.name()을 통해 "ADMIN"/"MERCHANT" 형태로 권한을 부여하지만, hasRole() 메소드는 내부적으로 "ROLE_" 접두사를 추가하여 불일치가 발생했습니다.
- hasAuthority() 메소드를 사용함으로써 접두사 없이 정확히 일치하는 권한을 검증하도록 수정했습니다.
- 향후 PaymentTokenAuthenticationFilter에서도 권한 부여 방식을 일관되게 유지할 필요가 있습니다.


