### PR TITLE
Feat/38: 가맹점 일일 정산(매출 전표 csv 파일 생성 및 SFTP 전송 Batch Job) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+    // Spring Batch
+    implementation 'org.apache.poi:poi-ooxml:5.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     implementation 'com.hierynomus:sshj:0.37.0'     // SFTP 프로토콜 지원
     implementation 'org.springframework.retry:spring-retry'
 
+    // Spring Quartz
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'org.apache.poi:poi-ooxml:5.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'com.hierynomus:sshj:0.37.0'     // SFTP 프로토콜 지원
+    implementation 'org.springframework.retry:spring-retry'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     // Spring Batch
     implementation 'org.apache.poi:poi-ooxml:5.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'com.hierynomus:sshj:0.37.0'     // SFTP 프로토콜 지원
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
+++ b/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
  * 가맹점별 일일 정산 요약 정보를 담는 불변 객체
  */
 public record MerchantSummary(
-        String merchantId,
+        Long merchantId,
         String merchantName,
         BigDecimal creditAmount,
         BigDecimal debitAmount,

--- a/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
+++ b/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
@@ -1,0 +1,16 @@
+package com.fisa.pg.batch.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 상점별 정산 요약 정보를 담는 불변 객체
+ */
+public record MerchantSummary(
+        String merchantId,
+        String merchantName,
+        BigDecimal totalAmount,
+        String currency,
+        LocalDateTime settlementDate
+) {
+}

--- a/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
+++ b/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
@@ -9,8 +9,8 @@ import java.time.LocalDateTime;
 public record MerchantSummary(
         String merchantId,
         String merchantName,
-        BigDecimal creditAmount,    // 신용카드 총액
-        BigDecimal checkAmount,     // 체크카드 총액
+        BigDecimal creditAmount,
+        BigDecimal debitAmount,
         BigDecimal totalAmount,
         String currency,
         LocalDateTime settlementDate

--- a/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
+++ b/src/main/java/com/fisa/pg/batch/dto/MerchantSummary.java
@@ -4,11 +4,13 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
- * 상점별 정산 요약 정보를 담는 불변 객체
+ * 가맹점별 일일 정산 요약 정보를 담는 불변 객체
  */
 public record MerchantSummary(
         String merchantId,
         String merchantName,
+        BigDecimal creditAmount,    // 신용카드 총액
+        BigDecimal checkAmount,     // 체크카드 총액
         BigDecimal totalAmount,
         String currency,
         LocalDateTime settlementDate

--- a/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
@@ -61,7 +61,7 @@ public class GenerateAndSendPurchaseCsvJob {
                                 ItemProcessor<Merchant, Merchant> merchantProcessor,
                                 ItemWriter<Merchant> merchantWriter) {
         return new StepBuilder("GenerateCsvAndSendSftpStep", jobRepository)
-                .<Merchant, Merchant>chunk(10, transactionManager)
+                .<Merchant, Merchant>chunk(5000, transactionManager)
                 .reader(merchantReader)
                 .processor(merchantProcessor)
                 .writer(merchantWriter)

--- a/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -65,6 +66,9 @@ public class GenerateAndSendPurchaseCsvJob {
                 .reader(merchantReader)
                 .processor(merchantProcessor)
                 .writer(merchantWriter)
+                .faultTolerant()
+                .retry(IOException.class)
+                .retryLimit(3)
                 .build();
     }
 

--- a/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
@@ -1,12 +1,13 @@
 package com.fisa.pg.batch.job_config;
 
+import com.fisa.pg.batch.dto.MerchantSummary;
 import com.fisa.pg.batch.utils.CsvGenerator;
 import com.fisa.pg.batch.utils.SftpUploader;
 import com.fisa.pg.entity.payment.Payment;
 import com.fisa.pg.entity.payment.PaymentStatus;
 import com.fisa.pg.entity.user.Merchant;
+import com.fisa.pg.repository.MerchantRepository;
 import com.fisa.pg.repository.PaymentRepository;
-import jakarta.persistence.EntityManagerFactory;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -14,95 +15,95 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.item.ItemProcessor;
-import org.springframework.batch.item.ItemReader;
-import org.springframework.batch.item.ItemWriter;
-import org.springframework.batch.item.database.JpaPagingItemReader;
-import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.io.File;
-import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
 @EnableBatchProcessing
 public class GenerateAndSendPurchaseCsvJob {
 
-    private final EntityManagerFactory entityManagerFactory;
     private final PaymentRepository paymentRepository;
+    private final MerchantRepository merchantRepository;
     private final CsvGenerator csvGenerator;
     private final SftpUploader sftpUploader;
 
-    public GenerateAndSendPurchaseCsvJob(EntityManagerFactory entityManagerFactory,
-                                         PaymentRepository paymentRepository,
-                                         CsvGenerator csvGenerator,
-                                         SftpUploader sftpUploader) {
-        this.entityManagerFactory = entityManagerFactory;
+    public GenerateAndSendPurchaseCsvJob(
+            PaymentRepository paymentRepository,
+            MerchantRepository merchantRepository,
+            CsvGenerator csvGenerator,
+            SftpUploader sftpUploader
+    ) {
         this.paymentRepository = paymentRepository;
+        this.merchantRepository = merchantRepository;
         this.csvGenerator = csvGenerator;
         this.sftpUploader = sftpUploader;
     }
 
     @Bean
-    public Job generateAndSendPurchaseCsvJob(JobRepository jobRepository, Step merchantCsvStep) {
+    public Job generateAndSendPurchaseCsvJob(JobRepository jobRepository,
+                                             Step settlementStep) {
         return new JobBuilder("GenerateAndSendPurchaseCsvJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
-                .start(merchantCsvStep)
+                .start(settlementStep)
                 .build();
     }
 
     @Bean
-    public Step merchantCsvStep(JobRepository jobRepository,
-                                PlatformTransactionManager transactionManager,
-                                ItemReader<Merchant> merchantReader,
-                                ItemProcessor<Merchant, Merchant> merchantProcessor,
-                                ItemWriter<Merchant> merchantWriter) {
-        return new StepBuilder("GenerateCsvAndSendSftpStep", jobRepository)
-                .<Merchant, Merchant>chunk(5000, transactionManager)
-                .reader(merchantReader)
-                .processor(merchantProcessor)
-                .writer(merchantWriter)
-                .faultTolerant()
-                .retry(IOException.class)
-                .retryLimit(3)
+    public Step settlementStep(JobRepository jobRepository,
+                               PlatformTransactionManager transactionManager) {
+        return new StepBuilder("SettlementSummaryStep", jobRepository)
+                .tasklet((contrib, ctx) -> {
+                    // 1) 어제 00:00:00 ~ 23:59:59
+                    LocalDate yesterday = LocalDate.now().minusDays(1);
+                    LocalDateTime start = yesterday.atStartOfDay();
+                    LocalDateTime end = yesterday.atTime(23, 59, 59);
+
+                    // 2) 정산 시각: 오늘 02:00
+                    LocalDateTime settlementTime = LocalDateTime.now()
+                            .withHour(2).withMinute(0).withSecond(0).withNano(0);
+
+                    // 3) 활성 가맹점 조회
+                    List<Merchant> merchants = merchantRepository.findByIsActiveTrue();
+
+                    // 4) 합계 계산 및 요약 DTO 생성
+                    List<MerchantSummary> summaries = new ArrayList<>();
+                    for (Merchant m : merchants) {
+                        List<Payment> payments = paymentRepository
+                                .findByMerchantAndPaymentStatusAndApprovedAtBetween(
+                                        m, PaymentStatus.SUCCEEDED, start, end);
+                        if (payments.isEmpty()) continue;
+
+                        BigDecimal total = payments.stream()
+                                .map(p -> BigDecimal.valueOf(p.getAmount()))
+                                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+                        summaries.add(new MerchantSummary(
+                                m.getBusinessNumber(), // MID000… 형식
+                                m.getName(),
+                                total,
+                                payments.get(0).getCurrency(),
+                                settlementTime
+                        ));
+                    }
+
+                    // 5) CSV 생성 & SFTP 전송
+                    File csv = csvGenerator.generateSummary(summaries);
+                    sftpUploader.upload(csv);
+
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .transactionManager(transactionManager)
                 .build();
-    }
-
-    @Bean
-    public JpaPagingItemReader<Merchant> merchantReader() {
-        return new JpaPagingItemReaderBuilder<Merchant>()
-                .name("ReadMerchantStep")
-                .entityManagerFactory(entityManagerFactory)
-                .queryString("SELECT m FROM Merchant m WHERE m.isActive = true")
-                .pageSize(10)
-                .build();
-    }
-
-    @Bean
-    public ItemProcessor<Merchant, Merchant> merchantProcessor() {
-        return merchant -> merchant; // 정산 시간 필터링이 필요하면 여기에 구현
-    }
-
-    @Bean
-    public ItemWriter<Merchant> merchantWriter() {
-        return merchants -> {
-            for (Merchant merchant : merchants) {
-                List<Payment> payments = paymentRepository.findByMerchantAndPaymentStatusAndApprovedAtBetween(
-                        merchant,
-                        PaymentStatus.SUCCEEDED,
-                        LocalDate.now().atStartOfDay(),
-                        LocalDate.now().plusDays(1).atStartOfDay()
-                );
-
-                if (payments.isEmpty()) continue;
-
-                File csv = csvGenerator.generate(merchant, payments);
-                sftpUploader.upload(csv);
-            }
-        };
     }
 }
+
+

--- a/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
@@ -105,7 +105,7 @@ public class GenerateAndSendPurchaseCsvJob {
                                                 BigDecimal totalSum = creditSum.add(debitSum);
 
                                                 return new MerchantSummary(
-                                                        m.getBusinessNumber(),
+                                                        m.getId(),
                                                         m.getName(),
                                                         creditSum,
                                                         debitSum,

--- a/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/GenerateAndSendPurchaseCsvJob.java
@@ -1,0 +1,106 @@
+package com.fisa.pg.batch.job_config;
+
+import com.fisa.pg.batch.utils.CsvGenerator;
+import com.fisa.pg.batch.utils.SftpUploader;
+import com.fisa.pg.entity.payment.Payment;
+import com.fisa.pg.entity.payment.PaymentStatus;
+import com.fisa.pg.entity.user.Merchant;
+import com.fisa.pg.repository.PaymentRepository;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.util.List;
+
+@Configuration
+@EnableBatchProcessing
+public class GenerateAndSendPurchaseCsvJob {
+
+    @Autowired
+    private JobBuilderFactory jobBuilderFactory;
+
+    @Autowired
+    private StepBuilderFactory stepBuilderFactory;
+
+    @Autowired
+    @Qualifier("dataEntityManager")
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private CsvGenerator csvGenerator;
+
+    @Autowired
+    private SftpUploader sftpUploader;
+
+    @Bean
+    public Job generateAndSendPurchaseCsvJob(Step merchantCsvStep) {
+        return jobBuilderFactory.get("GenerateAndSendPurchaseCsvJob")
+                .incrementer(new RunIdIncrementer())
+                .start(merchantCsvStep)
+                .build();
+    }
+
+    @Bean
+    public Step merchantCsvStep(
+            ItemReader<Merchant> merchantReader,
+            ItemProcessor<Merchant, Merchant> merchantProcessor,
+            ItemWriter<Merchant> merchantWriter
+    ) {
+        return stepBuilderFactory.get("GenerateCsvAndSendSftpStep")
+                .<Merchant, Merchant>chunk(10)
+                .reader(merchantReader)
+                .processor(merchantProcessor)
+                .writer(merchantWriter)
+                .build();
+    }
+
+    @Bean
+    public JpaPagingItemReader<Merchant> merchantReader() {
+        return new JpaPagingItemReaderBuilder<Merchant>()
+                .name("ReadMerchantStep")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT m FROM Merchant m WHERE m.isActive = true")
+                .pageSize(10)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<Merchant, Merchant> merchantProcessor() {
+        return merchant -> merchant; // 정산 시간 필터링이 필요하면 여기에 구현
+    }
+
+    @Bean
+    public ItemWriter<Merchant> merchantWriter() {
+        return merchants -> {
+            for (Merchant merchant : merchants) {
+                List<Payment> payments = paymentRepository.findByMerchantAndPaymentStatusAndCreatedAtBetween(
+                        merchant,
+                        PaymentStatus.SUCCEEDED,
+                        LocalDate.now().atStartOfDay(),
+                        LocalDate.now().plusDays(1).atStartOfDay()
+                );
+
+                if (payments.isEmpty()) continue;
+
+                File csv = csvGenerator.generate(merchant, payments);
+                sftpUploader.upload(csv);
+            }
+        };
+    }
+}

--- a/src/main/java/com/fisa/pg/batch/job_config/RetryTemplateConfig.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/RetryTemplateConfig.java
@@ -1,0 +1,29 @@
+package com.fisa.pg.batch.job_config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+@Configuration
+public class RetryTemplateConfig {
+
+    @Bean
+    public RetryTemplate sftpRetryTemplate() {
+        RetryTemplate retryTemplate = new RetryTemplate();
+
+        // 최대 재시도 횟수 3회
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+        retryPolicy.setMaxAttempts(3);
+
+        // 재시도 간 간격 2000ms
+        FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+        backOffPolicy.setBackOffPeriod(2000);
+
+        retryTemplate.setRetryPolicy(retryPolicy);
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+
+        return retryTemplate;
+    }
+}

--- a/src/main/java/com/fisa/pg/batch/job_config/RetryTemplateConfig.java
+++ b/src/main/java/com/fisa/pg/batch/job_config/RetryTemplateConfig.java
@@ -4,26 +4,23 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
 
 @Configuration
 public class RetryTemplateConfig {
 
+    // Tasklet 모델 재시도 전략(Chunk 모델과 달리 프레임워크에서 재시도 기능을 제공해주지 않음)
     @Bean
-    public RetryTemplate sftpRetryTemplate() {
-        RetryTemplate retryTemplate = new RetryTemplate();
+    public org.springframework.retry.support.RetryTemplate retryTemplate() {
+        org.springframework.retry.support.RetryTemplate template = new org.springframework.retry.support.RetryTemplate();
 
-        // 최대 재시도 횟수 3회
-        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
-        retryPolicy.setMaxAttempts(3);
+        SimpleRetryPolicy policy = new SimpleRetryPolicy();
+        policy.setMaxAttempts(3);                // 총 3회 시도
 
-        // 재시도 간 간격 2000ms
-        FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
-        backOffPolicy.setBackOffPeriod(2000);
+        FixedBackOffPolicy backOff = new FixedBackOffPolicy();
+        backOff.setBackOffPeriod(2000);          // 시도 간격 2초
 
-        retryTemplate.setRetryPolicy(retryPolicy);
-        retryTemplate.setBackOffPolicy(backOffPolicy);
-
-        return retryTemplate;
+        template.setRetryPolicy(policy);
+        template.setBackOffPolicy(backOff);
+        return template;
     }
 }

--- a/src/main/java/com/fisa/pg/batch/quartz/QuartzConfig.java
+++ b/src/main/java/com/fisa/pg/batch/quartz/QuartzConfig.java
@@ -1,0 +1,27 @@
+package com.fisa.pg.batch.quartz;
+
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuartzConfig {
+
+    @Bean
+    public JobDetail settlementJobDetail() {
+        return JobBuilder.newJob(QuartzJobLauncher.class)
+                .withIdentity("dailySettlementJob")
+                .usingJobData("jobName", "GenerateAndSendPurchaseCsvJob")
+                .storeDurably()
+                .build();
+    }
+
+    @Bean
+    public Trigger settlementJobTrigger(JobDetail jobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity("dailySettlementTrigger")
+                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 2 * * ?"))  // 매일 02:00
+                .build();
+    }
+}

--- a/src/main/java/com/fisa/pg/batch/quartz/QuartzJobLauncher.java
+++ b/src/main/java/com/fisa/pg/batch/quartz/QuartzJobLauncher.java
@@ -1,0 +1,36 @@
+package com.fisa.pg.batch.quartz;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+public class QuartzJobLauncher extends QuartzJobBean {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    // Bean 이름(메서드명)으로 등록된 Spring Batch Job을 주입
+    @Autowired
+    @Qualifier("generateAndSendPurchaseCsvJob")
+    private Job generateAndSendPurchaseCsvJob;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        try {
+            jobLauncher.run(
+                    generateAndSendPurchaseCsvJob,
+                    new JobParametersBuilder()
+                            .addLong("timestamp", System.currentTimeMillis())
+                            .toJobParameters()
+            );
+        } catch (Exception ex) {
+            // Quartz의 JobExecutionException을 던져야 Quartz가 재시도/오류 로깅을 합니다.
+            throw new JobExecutionException(ex);
+        }
+    }
+}

--- a/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
+++ b/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
@@ -9,6 +9,8 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Component
@@ -18,7 +20,9 @@ public class CsvGenerator {
     private String outputDirectory;
 
     public File generate(Merchant merchant, List<Payment> payments) throws IOException {
-        String fileName = "purchase_" + merchant.getId() + ".csv";
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String fileName = String.format("purchase_%d_%s.csv", merchant.getId(), timestamp);
+
         File dir = new File(outputDirectory);
         if (!dir.exists()) dir.mkdirs();
 

--- a/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
+++ b/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
@@ -1,5 +1,6 @@
 package com.fisa.pg.batch.utils;
 
+import com.fisa.pg.batch.dto.MerchantSummary;
 import com.fisa.pg.entity.payment.Payment;
 import com.fisa.pg.entity.user.Merchant;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +44,39 @@ public class CsvGenerator {
             }
         }
 
+        return csvFile;
+    }
+
+    /**
+     * 전체 요약 리스트로 단일 CSV 파일 생성
+     */
+    public File generateSummary(List<MerchantSummary> summaries) throws IOException {
+        String timestamp = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String fileName = String.format("purchase_summary_%s.csv", timestamp);
+
+        File dir = new File(outputDirectory);
+        if (!dir.exists()) dir.mkdirs();
+        File csvFile = new File(dir, fileName);
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(csvFile))) {
+            // 헤더
+            writer.write("merchantId,merchantName,total_amount,currency,settlement_date");
+            writer.newLine();
+
+            // 데이터
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            for (MerchantSummary ms : summaries) {
+                writer.write(String.join(",",
+                        ms.merchantId(),         // record 접근자
+                        ms.merchantName(),
+                        ms.totalAmount().toPlainString(),
+                        ms.currency(),
+                        ms.settlementDate().format(dtf)
+                ));
+                writer.newLine();
+            }
+        }
         return csvFile;
     }
 }

--- a/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
+++ b/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
@@ -1,0 +1,44 @@
+package com.fisa.pg.batch.utils;
+
+import com.fisa.pg.entity.payment.Payment;
+import com.fisa.pg.entity.user.Merchant;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class CsvGenerator {
+
+    @Value("${batch.output.directory}")
+    private String outputDirectory;
+
+    public File generate(Merchant merchant, List<Payment> payments) throws IOException {
+        String fileName = "purchase_" + merchant.getId() + ".csv";
+        File dir = new File(outputDirectory);
+        if (!dir.exists()) dir.mkdirs();
+
+        File csvFile = new File(dir, fileName);
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(csvFile))) {
+            writer.write("merchantId,orderId,amount,currency");
+            writer.newLine();
+
+            for (Payment payment : payments) {
+                writer.write(String.join(",",
+                        String.valueOf(merchant.getId()),
+                        payment.getOrderId(),
+                        String.valueOf(payment.getAmount()),
+                        payment.getCurrency()
+                ));
+                writer.newLine();
+            }
+        }
+
+        return csvFile;
+    }
+}

--- a/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
+++ b/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
@@ -32,15 +32,17 @@ public class CsvGenerator {
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(csvFile))) {
             // 헤더
-            writer.write("merchantId,merchantName,total_amount,currency,settlement_date");
+            writer.write("merchant_id,merchant_name,credit_card_amount,check_card_amount,total_amount,currency,settlement_date");
             writer.newLine();
 
             // 데이터
             DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
             for (MerchantSummary ms : summaries) {
                 writer.write(String.join(",",
-                        ms.merchantId(),         // record 접근자
+                        ms.merchantId(),
                         ms.merchantName(),
+                        ms.creditAmount().toPlainString(),
+                        ms.debitAmount().toPlainString(),
                         ms.totalAmount().toPlainString(),
                         ms.currency(),
                         ms.settlementDate().format(dtf)

--- a/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
+++ b/src/main/java/com/fisa/pg/batch/utils/CsvGenerator.java
@@ -1,8 +1,6 @@
 package com.fisa.pg.batch.utils;
 
 import com.fisa.pg.batch.dto.MerchantSummary;
-import com.fisa.pg.entity.payment.Payment;
-import com.fisa.pg.entity.user.Merchant;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -20,40 +18,13 @@ public class CsvGenerator {
     @Value("${batch.output.directory}")
     private String outputDirectory;
 
-    public File generate(Merchant merchant, List<Payment> payments) throws IOException {
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-        String fileName = String.format("purchase_%d_%s.csv", merchant.getId(), timestamp);
-
-        File dir = new File(outputDirectory);
-        if (!dir.exists()) dir.mkdirs();
-
-        File csvFile = new File(dir, fileName);
-
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(csvFile))) {
-            writer.write("merchantId,orderId,amount,currency");
-            writer.newLine();
-
-            for (Payment payment : payments) {
-                writer.write(String.join(",",
-                        String.valueOf(merchant.getId()),
-                        payment.getOrderId(),
-                        String.valueOf(payment.getAmount()),
-                        payment.getCurrency()
-                ));
-                writer.newLine();
-            }
-        }
-
-        return csvFile;
-    }
-
     /**
      * 전체 요약 리스트로 단일 CSV 파일 생성
      */
     public File generateSummary(List<MerchantSummary> summaries) throws IOException {
         String timestamp = LocalDateTime.now()
-                .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-        String fileName = String.format("purchase_summary_%s.csv", timestamp);
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmm"));
+        String fileName = String.format("pg_daily_settlement_summary_to_card_%s.csv", timestamp);
 
         File dir = new File(outputDirectory);
         if (!dir.exists()) dir.mkdirs();

--- a/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
+++ b/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
@@ -4,17 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
-import net.schmizz.sshj.xfer.LocalFileFilter;
-import net.schmizz.sshj.xfer.LocalSourceFile;
+import net.schmizz.sshj.xfer.FileSystemFile;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.retry.RetryCallback;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 @Slf4j
 @Component
@@ -43,80 +39,29 @@ public class SftpUploader {
 
     public void upload(File file) {
         if (file == null || !file.exists()) {
-            throw new IllegalArgumentException("전송할 파일이 존재하지 않습니다: " + file);
+            throw new IllegalArgumentException(">>>>>>>>>>>>>[Error]: 전송할 파일이 존재하지 않습니다: " + file);
         }
 
         try {
-            sftpRetryTemplate.execute((RetryCallback<Void, IOException>) context -> {
+            sftpRetryTemplate.execute(context -> {
+                // 기존 로직
                 try (SSHClient ssh = new SSHClient()) {
                     ssh.addHostKeyVerifier(new PromiscuousVerifier());
                     ssh.connect(sftpHost, sftpPort);
                     ssh.authPassword(sftpUsername, sftpPassword);
 
                     try (SFTPClient sftp = ssh.newSFTPClient()) {
-                        sftp.put(new LocalSourceFile() {
-                            @Override
-                            public String getName() {
-                                return file.getName();
-                            }
-
-                            @Override
-                            public long getLength() {
-                                return file.length();
-                            }
-
-                            @Override
-                            public InputStream getInputStream() throws IOException {
-                                return new FileInputStream(file);
-                            }
-
-                            @Override
-                            public boolean isFile() {
-                                return true;
-                            }
-
-                            @Override
-                            public boolean isDirectory() {
-                                return false;
-                            }
-
-                            @Override
-                            public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter localFileFilter) {
-                                return null;
-                            }
-
-                            @Override
-                            public boolean providesAtimeMtime() {
-                                return false;
-                            }
-
-                            @Override
-                            public long getLastAccessTime() {
-                                return 0;
-                            }
-
-                            @Override
-                            public long getLastModifiedTime() {
-                                return 0;
-                            }
-
-                            @Override
-                            public int getPermissions() {
-                                return 0644;
-                            }
-                        }, sftpRemoteDir + "/");
-
-                        log.info(">>>>>>>>>>>SFTP 전송 성공: {}", file.getName());
+                        sftp.put(new FileSystemFile(file), sftpRemoteDir + "/");
+                        log.info(">>>>>>>>>>>>>>SFTP 전송 성공: {}", file.getName());
                     }
                 } catch (IOException e) {
-                    log.warn(">>>>>>>>>>>SFTP 전송 재시도 중 오류 발생: {}", e.getMessage());
+                    log.warn(">>>>>>>>>>>>>>SFTP 전송 재시도 중 오류 발생: {}", e.getMessage());
                     throw e;
                 }
-
                 return null;
             });
-        } catch (IOException finalEx) {
-            throw new RuntimeException(">>>>>>>>>>>SFTP 최종 실패: " + file.getName(), finalEx);
+        } catch (IOException e) {
+            throw new RuntimeException(">>>>>>>>>>>>>>SFTP 최종 실패: " + file.getName(), e);
         }
     }
 }

--- a/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
+++ b/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
@@ -7,6 +7,8 @@ import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 import net.schmizz.sshj.xfer.LocalFileFilter;
 import net.schmizz.sshj.xfer.LocalSourceFile;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -33,79 +35,88 @@ public class SftpUploader {
     @Value("${batch.sftp.remote-dir}")
     private String sftpRemoteDir;
 
+    private final RetryTemplate sftpRetryTemplate;
+
+    public SftpUploader(RetryTemplate sftpRetryTemplate) {
+        this.sftpRetryTemplate = sftpRetryTemplate;
+    }
+
     public void upload(File file) {
         if (file == null || !file.exists()) {
             throw new IllegalArgumentException("전송할 파일이 존재하지 않습니다: " + file);
         }
 
-        sftpRetryTemplate.execute(context -> {
-            try (SSHClient ssh = new SSHClient()) {
-                ssh.addHostKeyVerifier(new PromiscuousVerifier());
-                ssh.connect(sftpHost, sftpPort);
-                ssh.authPassword(sftpUsername, sftpPassword);
+        try {
+            sftpRetryTemplate.execute((RetryCallback<Void, IOException>) context -> {
+                try (SSHClient ssh = new SSHClient()) {
+                    ssh.addHostKeyVerifier(new PromiscuousVerifier());
+                    ssh.connect(sftpHost, sftpPort);
+                    ssh.authPassword(sftpUsername, sftpPassword);
 
-                try (SFTPClient sftp = ssh.newSFTPClient()) {
-                    sftp.put(new LocalSourceFile() {
-                        @Override
-                        public String getName() {
-                            return file.getName();
-                        }
+                    try (SFTPClient sftp = ssh.newSFTPClient()) {
+                        sftp.put(new LocalSourceFile() {
+                            @Override
+                            public String getName() {
+                                return file.getName();
+                            }
 
-                        @Override
-                        public long getLength() {
-                            return file.length();
-                        }
+                            @Override
+                            public long getLength() {
+                                return file.length();
+                            }
 
-                        @Override
-                        public InputStream getInputStream() throws IOException {
-                            return new FileInputStream(file);
-                        }
+                            @Override
+                            public InputStream getInputStream() throws IOException {
+                                return new FileInputStream(file);
+                            }
 
-                        @Override
-                        public boolean isFile() {
-                            return true;
-                        }
+                            @Override
+                            public boolean isFile() {
+                                return true;
+                            }
 
-                        @Override
-                        public boolean isDirectory() {
-                            return false;
-                        }
+                            @Override
+                            public boolean isDirectory() {
+                                return false;
+                            }
 
-                        @Override
-                        public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter localFileFilter) {
-                            return null;
-                        }
+                            @Override
+                            public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter localFileFilter) {
+                                return null;
+                            }
 
-                        @Override
-                        public boolean providesAtimeMtime() {
-                            return false;
-                        }
+                            @Override
+                            public boolean providesAtimeMtime() {
+                                return false;
+                            }
 
-                        @Override
-                        public long getLastAccessTime() {
-                            return 0;
-                        }
+                            @Override
+                            public long getLastAccessTime() {
+                                return 0;
+                            }
 
-                        @Override
-                        public long getLastModifiedTime() {
-                            return 0;
-                        }
+                            @Override
+                            public long getLastModifiedTime() {
+                                return 0;
+                            }
 
-                        @Override
-                        public int getPermissions() {
-                            return 0644;
-                        }
-                    }, sftpRemoteDir + "/");
+                            @Override
+                            public int getPermissions() {
+                                return 0644;
+                            }
+                        }, sftpRemoteDir + "/");
 
-                    log.info(">>>>>>>>>>>>>>SFTP 전송 성공: {}", file.getName());
-
+                        log.info(">>>>>>>>>>>SFTP 전송 성공: {}", file.getName());
+                    }
+                } catch (IOException e) {
+                    log.warn(">>>>>>>>>>>SFTP 전송 재시도 중 오류 발생: {}", e.getMessage());
+                    throw e;
                 }
-            } catch (IOException e) {
-                log.warn(">>>>>>>>>>>>>>SFTP 전송 재시도 중 오류 발생: {}", e.getMessage());
-                throw e;
-            }
 
-            return null;
-        });
+                return null;
+            });
+        } catch (IOException finalEx) {
+            throw new RuntimeException(">>>>>>>>>>>SFTP 최종 실패: " + file.getName(), finalEx);
+        }
     }
 }

--- a/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
+++ b/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
@@ -2,11 +2,18 @@ package com.fisa.pg.batch.utils;
 
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.transport.verification.HostKeyVerifier;
+import net.schmizz.sshj.xfer.LocalSourceFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PublicKey;
+import java.util.Collections;
+import java.util.List;
 
 @Component
 public class SftpUploader {
@@ -32,14 +39,48 @@ public class SftpUploader {
         }
 
         try (SSHClient ssh = new SSHClient()) {
-            ssh.addHostKeyVerifier((hostname, port, key) -> true); // TODO: 실 운영 시엔 known_hosts 적용
+
+            ssh.addHostKeyVerifier(new HostKeyVerifier() {
+                @Override
+                public boolean verify(String hostname, int port, PublicKey key) {
+                    return true; // 실 서비스에서는 known_hosts 기반 검증을 해야 함
+                }
+
+                @Override
+                public List<String> findExistingAlgorithms(String hostname, int port) {
+                    // 안전하게 비워진 리스트 반환
+                    return Collections.emptyList();
+                }
+            });
+
             ssh.connect(sftpHost, sftpPort);
             ssh.authPassword(sftpUsername, sftpPassword);
 
-            try (SFTPClient sftp = ssh.newSFTPClient();
-                 FileInputStream fis = new FileInputStream(file)) {
+            try (SFTPClient sftp = ssh.newSFTPClient()) {
 
-                sftp.put(fis, sftpRemoteDir + "/" + file.getName());
+                LocalSourceFile sourceFile = new LocalSourceFile() {
+                    @Override
+                    public String getName() {
+                        return file.getName();
+                    }
+
+                    @Override
+                    public long getLength() {
+                        return file.length();
+                    }
+
+                    @Override
+                    public InputStream getInputStream() throws IOException {
+                        return new FileInputStream(file); // 이 시점에 스트림 열기
+                    }
+
+                    @Override
+                    public boolean isFile() {
+                        return true;
+                    }
+                };
+
+                sftp.put(sourceFile, sftpRemoteDir + "/");
             }
 
         } catch (IOException e) {

--- a/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
+++ b/src/main/java/com/fisa/pg/batch/utils/SftpUploader.java
@@ -1,0 +1,49 @@
+package com.fisa.pg.batch.utils;
+
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.sftp.SFTPClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+@Component
+public class SftpUploader {
+
+    @Value("${batch.sftp.host}")
+    private String sftpHost;
+
+    @Value("${batch.sftp.port:22}")
+    private int sftpPort;
+
+    @Value("${batch.sftp.username}")
+    private String sftpUsername;
+
+    @Value("${batch.sftp.password}")
+    private String sftpPassword;
+
+    @Value("${batch.sftp.remote-dir}")
+    private String sftpRemoteDir;
+
+    public void upload(File file) {
+        if (file == null || !file.exists()) {
+            throw new IllegalArgumentException("전송할 파일이 존재하지 않습니다: " + file);
+        }
+
+        try (SSHClient ssh = new SSHClient()) {
+            ssh.addHostKeyVerifier((hostname, port, key) -> true); // TODO: 실 운영 시엔 known_hosts 적용
+            ssh.connect(sftpHost, sftpPort);
+            ssh.authPassword(sftpUsername, sftpPassword);
+
+            try (SFTPClient sftp = ssh.newSFTPClient();
+                 FileInputStream fis = new FileInputStream(file)) {
+
+                sftp.put(fis, sftpRemoteDir + "/" + file.getName());
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("SFTP 전송 실패: " + file.getName(), e);
+        }
+    }
+}

--- a/src/main/java/com/fisa/pg/config/db/DataDBConfig.java
+++ b/src/main/java/com/fisa/pg/config/db/DataDBConfig.java
@@ -1,0 +1,59 @@
+package com.fisa.pg.config.db;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+        basePackages = "com.fisa.pg.repository",
+        entityManagerFactoryRef = "dataEntityManager",
+        transactionManagerRef = "dataTransactionManager"
+)
+public class DataDBConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource-data")
+    public DataSource dataDBSource() {
+
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean dataEntityManager() { // 엔티티들을 관리할 Manager
+
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+
+        em.setDataSource(dataDBSource());
+        em.setPackagesToScan(new String[]{"com.fisa.pg.entity"});
+        em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.hbm2ddl.auto", "update");
+        properties.put("hibernate.show_sql", "true");
+        em.setJpaPropertyMap(properties);
+
+        return em;
+    }
+
+    @Bean
+    public PlatformTransactionManager dataTransactionManager() {
+
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+
+        transactionManager.setEntityManagerFactory(dataEntityManager().getObject());
+
+        return transactionManager;
+    }
+}

--- a/src/main/java/com/fisa/pg/config/db/MetaDBConfig.java
+++ b/src/main/java/com/fisa/pg/config/db/MetaDBConfig.java
@@ -1,0 +1,30 @@
+package com.fisa.pg.config.db;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class MetaDBConfig {
+
+    @Primary    // Meta DB와 Data DB의 충돌 방지
+    @Bean(name = "dataSource")
+    @ConfigurationProperties(prefix = "spring.datasource-meta")
+    public DataSource metaDBSource() {
+
+        return DataSourceBuilder.create().build();
+    }
+    
+    @Primary
+    @Bean
+    public PlatformTransactionManager metaTransactionManager() {
+
+        return new DataSourceTransactionManager(metaDBSource());
+    }
+}

--- a/src/main/java/com/fisa/pg/repository/MerchantRepository.java
+++ b/src/main/java/com/fisa/pg/repository/MerchantRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MerchantRepository extends JpaRepository<Merchant, Long> {
@@ -22,4 +23,5 @@ public interface MerchantRepository extends JpaRepository<Merchant, Long> {
      */
     Page<Merchant> findByWebhookUrlIsNotNullAndIsWebhookEnabledTrue(Pageable pageable);
 
+    List<Merchant> findByIsActiveTrue();
 }

--- a/src/main/java/com/fisa/pg/repository/PaymentRepository.java
+++ b/src/main/java/com/fisa/pg/repository/PaymentRepository.java
@@ -1,9 +1,12 @@
 package com.fisa.pg.repository;
 
 import com.fisa.pg.entity.payment.Payment;
+import com.fisa.pg.entity.payment.PaymentStatus;
 import com.fisa.pg.entity.user.Merchant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
@@ -16,4 +19,11 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
      * @return 결제 정보
      */
     Optional<Payment> findByOrderIdAndMerchant(String orderId, Merchant merchant);
+
+    List<Payment> findByMerchantAndPaymentStatusAndApprovedAtBetween(
+            Merchant merchant,
+            PaymentStatus paymentStatus,
+            LocalDateTime start,
+            LocalDateTime end
+    );
 }


### PR DESCRIPTION
### [PG서버 Batch Job] 매입 파일 생성 및 SFTP 전송 Job

- **Job 이름**: **`GenerateAndSendPurchaseCsvJob`**
- **Trigger 시간**: 가맹점마다 설정한 정산 시간 기준 (Quartz 사용)
- **Step 로직 구성**:
    - 정산 시간이 지난 승인 상태 결제 데이터 조회
    - 가맹점별로 일자 기준으로 결제 데이터 그룹화
    - 각 가맹점별로 하나의 매입 CSV 파일 생성
    - SFTP 로 카드사 서버에 전송
- **고려 사항**:
    - JobParameter에 가맹점 ID나 정산 시간 기준을 전달
    - 실패 시 재전송 로직 필요
    - 전송 성공 여부를 Meta_DB에 저장

### 참고 사항
> 현재 secret.yml 공유가 안돼서 CI 빌드 에러 나는 부분은 아래를 참고하여 설정파일 수정해야 합니다!
- Spring Quartz 기반 글로벌 락 적용(중복 배치 작업 방지)
     - secret.yml 설정 필수!!
     - <img width="619" alt="Image" src="https://github.com/user-attachments/assets/337dfe75-d54e-4786-a11b-31cec0df7136" />